### PR TITLE
Feature/#67 modify webpack setting

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -8,6 +8,10 @@
     "last 2 versions",
     "safari >= 7"
   ],
+  "sideEffects": [
+    "*.css",
+    "*.scss"
+  ],
   "dependencies": {
     "@babel/runtime-corejs3": "^7.22.6",
     "@reduxjs/toolkit": "^1.9.5",

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,11 +1,11 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="manifest" href="/manifest.json" />
-    <title>Market Project</title>
+    <title>msg market</title>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/webpack.prod.js
+++ b/frontend/webpack.prod.js
@@ -13,7 +13,7 @@ module.exports = merge(common, {
   cache: {
     type: 'filesystem',
   },
-  devtool: 'hidden-source-map',
+  devtool: 'cheap-module-source-map',
   module: {
     rules: [
       {
@@ -55,27 +55,31 @@ module.exports = merge(common, {
         },
       }),
     ],
+
     splitChunks: {
+      chunks: 'all',
       cacheGroups: {
-        common: {
+        vendors: {
           test: /[\\/]node_modules[\\/]/,
-          name: 'app_node_modules',
+          name: 'vendors',
           chunks: 'initial',
-          minSize: 0,
           priority: 20,
-          reuseExistingChunk: true,
         },
-        default: {
-          minChunks: 2,
+        appModules: {
+          test: /[\\/]src[\\/]/,
+          name: 'app-modules',
+          chunks: 'initial',
+          priority: 15,
+        },
+        asyncVendors: {
+          test: /[\\/]node_modules[\\/]/,
+          chunks: 'async',
+          reuseExistingChunk: true,
           priority: 10,
-          reuseExistingChunk: true,
-        },
-        defaultVendors: false,
-        reactPackage: {
-          test: /[\\/]node_modules[\\/](react|react-dom|react-router|react-router-dom)[\\/]/,
-          name: 'react',
-          chunks: 'all',
-          priority: 30,
+          name(module) {
+            const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
+            return `async-${packageName.replace('@', '')}`;
+          },
         },
       },
     },

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -2436,15 +2436,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001503:
-  version "1.0.30001514"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001514.tgz#e2a7e184a23affc9367b7c8d734e7ec4628c1309"
-  integrity sha512-ENcIpYBmwAAOm/V2cXgM7rZUrKKaqisZl4ZAI520FIkqGXUxJjmaIssbRW5HVVR5tyV6ygTLIm15aU8LUmQSaQ==
-
-caniuse-lite@^1.0.30001449:
-  version "1.0.30001480"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001480.tgz#9bbd35ee44c2480a1e3a3b9f4496f5066817164a"
-  integrity sha512-q7cpoPPvZYgtyC4VaBSN0Bt+PJ4c4EYRf0DrduInOz2SkFpHD5p3LnvEpqBp7UnJn+8x1Ogl1s38saUxe+ihQQ==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001449, caniuse-lite@^1.0.30001503:
+  version "1.0.30001566"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001566.tgz"
+  integrity sha512-ggIhCsTxmITBAMmK8yZjEhCO5/47jKXPu6Dha/wuCS4JePVL+3uiDEBuhu2aIoT+bqTOR8L76Ip1ARL9xYsEJA==
 
 chalk@^2.0.0:
   version "2.4.2"


### PR DESCRIPTION
### 📅 PR 생성 날짜

- 2023.12.08

### 💬 작업 내용

**1. splitchunks 설정 변경**
리액트 관련 모듈만 로드 하는 것에서 초기 로드(intial)에 필요한 모듈들을 청크로 분리.
```js
vendors: {
  test: /[\\/]node_modules[\\/]/,
  name: 'vendors',
  chunks: 'initial',
  priority: 20,
}
```
src 내부의 공통 컴포넌트(layout), util 함수, rtk slice등을 청크로 분리.
```js
appModules: {
  test: /[\\/]src[\\/]/,
  name: 'app-modules',
  chunks: 'initial',
  priority: 15,
}
```
비동기적으로 로드되는 모듈에 대해서 모듈 이름을 기반으로 청크 이름을 생성.
```js
asyncVendors: {
  test: /[\\/]node_modules[\\/]/,
  chunks: 'async',
  reuseExistingChunk: true,
  priority: 10,
  name(module) {
    const packageName = module.context.match(/[\\/]node_modules[\\/](.*?)([\\/]|$)/)[1];
    return `async-${packageName.replace('@', '')}`;
  },
}
```


**2. 트리쉐이킹 최적화를 위해 package.json에 sideEffects 속성 추가**
```json
module.exports = {
  // ...
  "sideEffects": [
    "*.css",
    "*.scss"
  ],
}
```

**3. index.html title 변경**
- `Market Project` -> `msg market`으로 변경
